### PR TITLE
Skip error when BigInt types are missing

### DIFF
--- a/src/cloneTypedArray.ts
+++ b/src/cloneTypedArray.ts
@@ -35,9 +35,7 @@ const TypedArrayMap: Record<string, TypedArrayConstructorType> = {
   "[object Uint8Array]": Uint8Array,
   "[object Uint16Array]": Uint16Array,
   "[object Uint32Array]": Uint32Array,
-  "[object Uint8ClampedArray]": Uint8ClampedArray,
-  "[object BigInt64Array]": BigInt64Array,
-  "[object BigUint64Array]": BigUint64Array,
+  "[object Uint8ClampedArray]": Uint8ClampedArray
 };
 
 /**
@@ -48,6 +46,11 @@ const TypedArrayMap: Record<string, TypedArrayConstructorType> = {
  * @returns {Object} Returns the cloned typed array.
  */
 export function cloneTypedArray(typedArray: TypedArrayType): TypedArrayType {
+  try{
+    TypedArrayMap["[object BigInt64Array]"] = BigInt64Array;
+    TypedArrayMap["[object BigUint64Array]"] = BigUint64Array;  
+  }catch(e){}
+  
   const buffer = cloneArrayBuffer(typedArray.buffer);
   return new TypedArrayMap[Object.prototype.toString.call(typedArray)](
     buffer,


### PR DESCRIPTION
This PR is trying to address #13 issue, in order to support Safari browser